### PR TITLE
Removed mogenius from deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,6 @@ global.BotName = "A17";
 </h2>
 <br>
 <br>
-<h2 align="center"> ✨  Deploy On Mogenius  ✨ </h2>
-
-<h2 align="center">
-  <a href="https://studio.mogenius.com/studio/cloud-space/cloud-space-overview">
-    <img title="A17 on Mogenius" src="https://img.shields.io/badge/DEPLOY MOGENIUS-h?color=blue&style=for-the-badge&logo=genius">
-  </a>
-</h2>
-<br>
-<br>
 <h2 align="center"> 🍃  Deploy On Railway  🍃 </h2>
 
 <h2 align="center">


### PR DESCRIPTION
Hi there, mogenius doesn't have free cloud resources anymore. It is possible to deploy the container for free but it requires a local Kubernetes. I suppose this is not a use case for this app so I suggest to remove mogenius from the deployment guide.